### PR TITLE
Some kinda JS syntax thing

### DIFF
--- a/links.js
+++ b/links.js
@@ -97,7 +97,7 @@ module.exports = function (indexes, links, version) {
           return o
         }),
         isArray(opts.query) ? mfr(opts.query) : pull.through(),
-        opts.limit ? pull.take(opts.limit) : pull.through(),
+        opts.limit ? pull.take(opts.limit) : pull.through()
       )
     }
     return index


### PR DESCRIPTION
Fixes:

```
/usr/local/lib/node_modules/scuttlebot/node_modules/flumeview-query/links.js:101
      )
      ^
SyntaxError: Unexpected token )
    at createScript (vm.js:53:10)
    at Object.runInThisContext (vm.js:95:10)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/scuttlebot/node_modules/ssb-links/index.js:2:23)
```